### PR TITLE
addresses (some) warnings/notes on R cmd check

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,8 @@ License: MIT + file LICENSE
 URL: https://github.com/ibarraespinosa/vein
 BugReports: https://github.com/ibarraespinosa/vein/issues/
 LazyData: no
-Depends: sp,  units, R (>= 2.10)
-Imports:   graphics, raster, rgeos, rgdal, stats
+Depends: R (>= 2.10), sp
+Imports: graphics, raster, rgeos, stats, units
 Suggests: maptools, ggplot2, RQGIS, knitr, rmarkdown, DiagrammeR, RColorBrewer
 RoxygenNote: 6.0.1
 NeedsCompilation: no

--- a/R/imports.R
+++ b/R/imports.R
@@ -1,0 +1,1 @@
+#' @importFrom units parse_unit

--- a/R/print.EmissionFactors.R
+++ b/R/print.EmissionFactors.R
@@ -1,5 +1,5 @@
 #' @export
-print.EmissionFactors <- function(ef, ...) {
-  cat("Result for EmissionFactors")
-  print(unclass(ef),  ...)
+print.EmissionFactors <- function(x, ...) {
+  cat("Result for EmissionFactors:\n")
+  NextMethod()
 }

--- a/R/print.EmissionFactorsList.R
+++ b/R/print.EmissionFactorsList.R
@@ -1,13 +1,13 @@
 #' @export
-print.EmissionFactorsList <- function(ef, default = F, ...) {
-  if ( default == TRUE ) {
-    print.listof(ef)
-  } else if ( is.function( ef[[1]] ) ){
-    cat("This EmissionFactorsList has", length(ef),
-        "functions")
-  } else if ( is.list(ef) && is.list(ef[[1]]) ) {
-    cat("This EmissionFactorsList has ", length(ef), "lists\n")
-    cat("First has",length(ef[[1]]), "functions\n")
-    cat("Last has", length(ef[[length(ef)]]), "functions")
+print.EmissionFactorsList <- function(x, ..., default = FALSE) {
+  if ( default ) {
+    print.listof(x)
+  } else if ( is.function( x[[1]] ) ){
+    cat("This EmissionFactorsList has ", length(x),
+        " functions")
+  } else if ( is.list(x) && is.list(x[[1]]) ) {
+    cat("This EmissionFactorsList has ", length(x), " lists\n")
+    cat("First has ",length(x[[1]]), " functions\n")
+    cat("Last has ", length(x[[length(x)]]), " functions")
   }
 }


### PR DESCRIPTION
print methods should have the signature `print(x,...,other_args)`; I corrected two, when you do the rest of them, both NOTE and WARNING will disappear. Pls check carefully to rename the first argument to `x` throughout the function.

Does `R CMD check` run checks on some of the functionality of the package?